### PR TITLE
Support duplex streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,18 @@ module.exports = function (connect, factor, max) {
     }
   }
 
+  isConnected.duplex = function (fn) {
+    return function () {
+      var args = [].slice.call(arguments)
+      if(state) return fn.apply(null, args)
+      var duplex = defer.duplex()
+      waiting.push(function () {
+        duplex.resolve(fn.apply(null, args))
+      })
+      return duplex
+    }
+  }
+
   tryConnect()
 
   return isConnected

--- a/test/index.js
+++ b/test/index.js
@@ -110,5 +110,31 @@ tape('delay sink', function (t) {
 
 })
 
+tape('delay duplex, sync', function (t) {
+  t.plan(2)
 
+  var ready = false
+  var r = Reconnect(function (isConnected) {
+    isConnected(ready = true)
+  })
+
+  var what = r.duplex(function (cb) {
+    return {
+      source: pull.values([1,2,3]),
+      sink: pull.collect(cb)
+    }
+  })
+
+  const duplex = what(function (err, ary) {
+    if(err) throw err
+    t.deepEqual(ary, [1,2,3])
+  })
+
+  pull(pull.values([1,2,3]), duplex)
+
+  pull(duplex, pull.collect(function (err, ary) {
+    if(err) throw err
+    t.deepEqual(ary, [1,2,3])
+  }))
+})
 


### PR DESCRIPTION
Hi! I added support for duplex streams so pull-reconnect can handle all types occurring in a muxrpc manifest. 